### PR TITLE
Use HTTPS everywhere

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ description: >
   personal goals we collaborating often and want others to share in this 
   experience.
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "http://cryptic-io" # the base hostname & protocol for your site
+url: "https://cryptic-io" # the base hostname & protocol for your site
 permalink: :title/
 paginate: 13
 

--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -13,7 +13,7 @@
     (function () {
         var s = document.createElement('script'); s.async = true;
         s.type = 'text/javascript';
-        s.src = 'http://' + disqus_shortname + '.disqus.com/count.js';
+        s.src = '//' + disqus_shortname + '.disqus.com/count.js';
         parent.appendChild(s);
     }());
 </script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -98,7 +98,7 @@
     <link rel="stylesheet" href="{{ '/styles.css' | prepend: site.baseurl }}">
     <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
-    <link href="http://fonts.googleapis.com/css?family=Open+Sans:400italic,400,600" rel="stylesheet" type="text/css">
+    <link href="//fonts.googleapis.com/css?family=Open+Sans:400italic,400,600" rel="stylesheet" type="text/css">
     <link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 
     {% include google-analytics.html %}


### PR DESCRIPTION
Was seeing a few mixed content errors while navigating around the site. Hopefully this will fix that.

Also of note: going to [http://cryptic.io](http://cryptic.io) will redirect you to [https://cryptic.io](https://cryptic.io), but only on the homepage. Might be worth turning on the CloudFlare Page Rule "Always use HTTPS" so all other pages redirect to https. @MarcoPolo, @mediocregopher, or @kinghrothgar should be able to enable that.
