### PR TITLE
Display where an article was cross-posted

### DIFF
--- a/_includes/css/post.css
+++ b/_includes/css/post.css
@@ -155,6 +155,24 @@
     background: {{ page.blue }};
 }
 
+.post-crosspost-container {
+  width: 100%;
+  background: #333;
+  color: #fff;
+  padding: 11px 15px;
+  font-size: 80%;
+}
+
+.post-crosspost-container a {
+  color: #fff;
+  font-weight: bold;
+  text-decoration: none;
+}
+
+.post-crosspost-container a:hover {
+  text-decoration: underline;
+}
+
 
 /*  General  */
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -53,6 +53,12 @@ layout: default
 
         </div>
 
+        {% if page.crosspost %}
+          <div class="post-crosspost-container">
+            This was cross-posted on <a href="{{ page.crosspost }}">{{page.crosspost}}</a>
+          </div>
+        {% endif %}
+
         <article id="post-content">
 
             {{ content }}

--- a/_posts/2014-09-27-shellshock.markdown
+++ b/_posts/2014-09-27-shellshock.markdown
@@ -3,6 +3,7 @@ layout: post
 title: Shellshock DIY
 tags: aws apache bash
 username: akenn
+crosspost: https://akenn.org/blog/shellshock/
 ---
 
 When [news of Shellshock first broke](http://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2014-6271), the main vector of attack was any application running on an Apache server via CGI. I don't run any Apache servers anymore, and if I did I probably wouldn't be running them with CGI (just not my preference). However, I wanted to try this bug out and I didn't want to do so in a malicious manner; I simply wanted to see what it did.

--- a/_posts/2014-10-05-staticshowdown-postmortem.markdown
+++ b/_posts/2014-10-05-staticshowdown-postmortem.markdown
@@ -4,6 +4,7 @@ title: Sock Singles, a post mortem on our static showdown entry
 tags: clojurescript javascript react firebase
 username: marcopolo
 demo: "https://sock-singles.firebaseapp.com/"
+crosspost: http://marcopolo.io/2014/02/11/staticshowdown-postmortem.html
 ---
 
 # Static Showdown

--- a/_posts/2014-10-28-clojure-diamond-square.markdown
+++ b/_posts/2014-10-28-clojure-diamond-square.markdown
@@ -4,6 +4,7 @@ title: Random Terrain Generation, A Clojure Walkthrough
 tags: clojure terrain
 username: mediocregopher
 source: "https://github.com/mediocregopher/diamond-square"
+crosspost: http://blog.mediocregopher.com/clojure-diamond-square.html
 ---
 
 ![terrain][terrain]


### PR DESCRIPTION
I thought it would be cool to link to other places where an article was posted. Here's what that looks like:

![screen shot 2015-01-20 at 12 29 03 pm](https://cloud.githubusercontent.com/assets/405000/5825401/dfba173c-a09f-11e4-82ed-113534c647e4.png)

Let me know if there are any articles I missed.