### PR TITLE
Fix site base url

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,7 +8,7 @@ description: >
   personal goals we collaborating often and want others to share in this 
   experience.
 baseurl: "" # the subpath of your site, e.g. /blog/
-url: "https://cryptic-io" # the base hostname & protocol for your site
+url: "https://cryptic.io" # the base hostname & protocol for your site
 permalink: :title/
 paginate: 13
 


### PR DESCRIPTION
I noticed twitter share link was including the wrong url. This should fix that. This won't break anything right?